### PR TITLE
Fix NameError in verify_preprocessing when validating chunk_size_bytes

### DIFF
--- a/openverifiablellm/verify.py
+++ b/openverifiablellm/verify.py
@@ -285,12 +285,6 @@ def verify_preprocessing(
             actual=raw_merkle_actual,
             detail=f"Merkle root of raw dump (chunk={chunk_size} bytes)",
         )
-        _check_field(
-            report, "manifest_chunk_size_bytes",
-            expected=manifest.get("chunk_size_bytes"),
-            actual=reproduced_manifest.get("chunk_size_bytes"),
-            detail="Merkle chunk size used during preprocessing",
-        )
     else:
         report.add(CheckResult(
             name="raw_merkle_root",
@@ -416,6 +410,16 @@ def verify_preprocessing(
                 actual=reproduced_manifest.get("preprocessing_version"),
                 detail="Preprocessing version tag",
             )
+            # verify chunk size recorded in the manifest matches whatever
+            # the preprocessing run produced. this needs the reproduced
+            # manifest, so we only perform it once the file has been loaded.
+            if "chunk_size_bytes" in manifest:
+                _check_field(
+                    report, "manifest_chunk_size_bytes",
+                    expected=manifest.get("chunk_size_bytes"),
+                    actual=reproduced_manifest.get("chunk_size_bytes"),
+                    detail="Merkle chunk size used during preprocessing",
+                )
         else:
             report.add(CheckResult(
                 name="manifest_regenerated",

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -221,6 +221,8 @@ class TestHappyPath(TmpMixin):
             "manifest_exists", "raw_file_exists", "raw_sha256",
             "processed_sha256", "dump_date", "wikipedia_dump_name",
             "python_version", "reprocessing_succeeded",
+            # new fields added in verification
+            "manifest_preprocessing_version", "manifest_chunk_size_bytes",
         ):
             self.assertIn(required, names)
 
@@ -232,6 +234,16 @@ class TestHappyPath(TmpMixin):
     def test_processed_sha256_check_passes(self):
         r = verify_preprocessing(self.dump, project_root=self.tmp)
         c = next(x for x in r.checks if x.name == "processed_sha256")
+        self.assertEqual(c.status, CheckStatus.PASS)
+
+    def test_manifest_preprocessing_version_check_passes(self):
+        r = verify_preprocessing(self.dump, project_root=self.tmp)
+        c = next(x for x in r.checks if x.name == "manifest_preprocessing_version")
+        self.assertEqual(c.status, CheckStatus.PASS)
+
+    def test_manifest_chunk_size_check_passes(self):
+        r = verify_preprocessing(self.dump, project_root=self.tmp)
+        c = next(x for x in r.checks if x.name == "manifest_chunk_size_bytes")
         self.assertEqual(c.status, CheckStatus.PASS)
 
     def test_merkle_checks_pass_or_skip(self):
@@ -369,6 +381,8 @@ class TestLegacyManifest(TmpMixin):
             c = next((x for x in r.checks if x.name == name), None)
             self.assertIsNotNone(c, f"check '{name}' not found")
             self.assertEqual(c.status, CheckStatus.SKIP)
+        # legacy manifests should not even contain the chunk-size
+        self.assertFalse(any(c.name == "manifest_chunk_size_bytes" for c in r.checks))
 
     def test_other_checks_still_pass(self):
         r = verify_preprocessing(self.dump, project_root=self.tmp)


### PR DESCRIPTION
### Addressed Issues
N/A (bug discovered while running the test suite locally)


### Screenshots / Recordings
<img width="1919" height="1085" alt="Screenshot 2026-03-07 205921" src="https://github.com/user-attachments/assets/c21968d0-4f70-4cb5-8969-60f179aa4264" />

This PR fixes a runtime error discovered while executing the test suite.


### Additional Notes

While running the test suite, a `NameError` was raised in `verify_preprocessing` because
`reproduced_manifest` was referenced before it was assigned when validating
`chunk_size_bytes`.

**Root Cause**

The validation for `manifest_chunk_size_bytes` was executed before the
`reproduced_manifest` object was created.

**Fix**

This PR resolves the issue by:

- Moving the `manifest_chunk_size_bytes` validation to execute **after** the reproduced manifest is created.
- Adding a guard so the check only runs when `chunk_size_bytes` exists in the original manifest (ensuring compatibility with legacy manifests).
- Adding tests to verify the corrected validation behavior.

**Test Results**

All tests pass locally:





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest verification logic with conditional validation checks that execute only when required data is available, enhancing robustness.

* **Tests**
  * Extended test coverage to validate manifest preprocessing and chunk size verification checks across different manifest scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->