### PR TITLE
[Feature]: Add environment verification

### DIFF
--- a/openverifiablellm/verify.py
+++ b/openverifiablellm/verify.py
@@ -3,7 +3,7 @@ Deterministic Preprocessing Verification Mode
 ==============================================
 
 Re-runs dataset preprocessing from scratch and validates that all
-generated artifacts (SHA256, Merkle roots, manifest fields) match
+generated artifacts (SHA256, Merkle roots, manifest fields, environment hash) match
 the previously recorded manifest exactly.
 
 Usage (CLI):
@@ -29,6 +29,7 @@ import subprocess
 import os
 
 from openverifiablellm import utils
+from openverifiablellm.environment import generate_environment_fingerprint
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +326,24 @@ def verify_preprocessing(
             actual=python_ver,
         ))
 
+    # checks environment hash
+    if "environment_hash" in manifest:
+        current_env = generate_environment_fingerprint()
+
+        _check_field(
+            report,
+            "environment_hash",
+            expected=manifest.get("environment_hash"),
+            actual=current_env["environment_hash"],
+            detail="Environment fingerprint comparison"
+        )
+    else:
+        report.add(CheckResult(
+            name="environment_hash",
+            status=CheckStatus.SKIP,
+            detail="Field absent from manifest (older version)"
+        ))
+    
     # 4. Re-run preprocessing in an isolated temp directory
     tmp_dir = Path(tempfile.mkdtemp(prefix="ovllm_verify_"))
     try:


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #57 

1. Recompute the environment fingerprint during verification:
   
    ```python
      current_env = generate_environment_fingerprint()
      current_hash = manifest.get("environment_hash")
    ```

2. Compare the computed hash with the value stored in the manifest:
     
    ```python
        _check_field(
            report,
            "environment_hash",
            expected=manifest.get("environment_hash"),
            actual=current_env["environment_hash"],
            detail="Environment fingerprint comparison"
        )
    ```

3. Maintain backward compatibility:
    If `environment_hash` is missing from older manifests, the check returns SKIP just like how Merkle root is handled.

###  Screenshots/Recordings:
<img width="1055" height="758" alt="image" src="https://github.com/user-attachments/assets/198abd2d-9bfd-486c-80d7-1cc48bd2612f" />


Now the system verifies `environment_hash` too.


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

## ⚠️ AI Notice - Important!

 We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.
