### PR TITLE
build: bump tokenizers to >=0.21.0 for Windows ARM64 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.9"
 dependencies = [
     "defusedxml",
     "sentencepiece",
-    "tokenizers==0.15.2"
+    "tokenizers>=0.21.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.9"
 dependencies = [
     "defusedxml",
     "sentencepiece",
-    "tokenizers>=0.21.0",
+    "tokenizers>=0.21.0,<1.0.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Problem
`tokenizers==0.15.2` has no pre-built wheel for Windows ARM64 (Snapdragon X Elite). This causes `link.exe` build errors and blocks all Windows ARM64 contributors from setting up the project.

## Fix
Relaxed the pin from `==0.15.2` to `>=0.21.0,<1.0.0`. Version `0.21.0` and above ship official ARM64 Windows wheels on PyPI, enabling seamless installation on newer hardware.

## Verified on
- Windows 11 ARM64 (Snapdragon X Elite)
- 113/113 tests passing after change (verified with `uv run pytest tests/ -v`)

## Impact
Unblocks Windows ARM64 contributors — an increasingly common hardware platform (Microsoft Copilot+ PCs). This improves the project's accessibility and developer experience for modern Windows environments.

## Checklist
- [x] My code follows the project's code style and conventions
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tokenizers dependency constraints to support a wider range of versions (0.21.0 and above, below 1.0.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->