### PR TITLE
Fix VerificationReport to preserve original input_dump path

### DIFF
--- a/openverifiablellm/verify.py
+++ b/openverifiablellm/verify.py
@@ -232,6 +232,9 @@ def verify_preprocessing(
     VerificationReport
         Structured report with per-check pass/fail results.
     """
+
+    original_input_dump = str(input_dump)
+
     input_dump = Path(input_dump).resolve()
     root = project_root or Path.cwd()
 
@@ -244,7 +247,7 @@ def verify_preprocessing(
         previous_manifest_path = Path(previous_manifest_path).resolve()
 
     report = VerificationReport(
-        input_dump=str(input_dump),
+        input_dump=original_input_dump,
         manifest_path=str(manifest_path),
         previous_manifest_path=str(previous_manifest_path) if previous_manifest_path else None,
     )


### PR DESCRIPTION
### Addressed Issues:

Fixes #74

### Screenshots/Recordings:

N/A

### Additional Notes:

This PR fixes an issue in `verify_preprocessing()` where `Path.resolve()` modified the user-provided `input_dump` path before storing it in `VerificationReport.input_dump`.

Changes made:

* Preserved the original `input_dump` path string before calling `Path.resolve()`
* Continued using the resolved path internally for processing and validation
* Updated `VerificationReport.input_dump` to store the original user-supplied path

Validation performed:

* `tests/test_verify.py::TestHappyPath::test_report_stores_input_dump_path` → Passed
* Full `tests/test_verify.py` suite → 37/37 tests passed
* Full project test suite executed; unrelated failures in `experiments/checkpoint_reproducibility` were observed due to platform-specific `/tmp` path handling on Windows and are not introduced by this change

## Checklist

* [x] My code follows the project's code style and conventions
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or errors
* [ ] I have joined the Discord server and I will share a link to this PR with the project maintainers there
* [x] I have read the Contributing Guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verification reports to preserve the original input_dump value instead of the converted path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/OpenVerifiableLLM/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->