### PR TITLE
fix: version the Merkle construction so pre-hardening manifests still verify

### DIFF
--- a/src/artifacts.py
+++ b/src/artifacts.py
@@ -67,25 +67,61 @@ def tensor_mapping_sha256(tensors: Dict[str, "torch.Tensor"]) -> str:
     return h.hexdigest()
 
 
-def _merkle_leaf(leaf_hash: bytes) -> bytes:
+# Merkle tree constructions, named so a manifest is self-describing.
+#
+# "sha256-concat" is the original construction: leaves are the raw chunk
+# digests and a parent is sha256(left + right). It is vulnerable to the
+# classic second-preimage attack -- an internal node can be replayed as a
+# leaf, so a shallower tree can be forged to the same root.
+#
+# "rfc6962-sha256" prefixes leaves with 0x00 and internal nodes with 0x01
+# (Certificate Transparency, RFC 6962 section 2.1), which domain-separates
+# the two and closes that attack.
+#
+# Manifests written before the hardening carry no algorithm field. Readers
+# MUST treat a missing field as MERKLE_ALG_LEGACY: those roots were produced
+# by the old construction, and defaulting to the new one reports an untampered
+# artifact as a hash mismatch.
+MERKLE_ALG_LEGACY = "sha256-concat"
+MERKLE_ALG_RFC6962 = "rfc6962-sha256"
+MERKLE_ALG_DEFAULT = MERKLE_ALG_RFC6962
+MERKLE_ALGS = (MERKLE_ALG_LEGACY, MERKLE_ALG_RFC6962)
+
+
+def _require_merkle_alg(alg: str) -> str:
+    if alg not in MERKLE_ALGS:
+        raise ValueError(f"unknown merkle_alg {alg!r}; expected one of {MERKLE_ALGS}")
+    return alg
+
+
+def _merkle_leaf(leaf_hash: bytes, alg: str = MERKLE_ALG_DEFAULT) -> bytes:
+    if alg == MERKLE_ALG_LEGACY:
+        return leaf_hash
     return compute_sha256_bytes(data=b"\x00" + leaf_hash)
 
 
-def _merkle_parent(left: bytes, right: bytes) -> bytes:
+def _merkle_parent(left: bytes, right: bytes, alg: str = MERKLE_ALG_DEFAULT) -> bytes:
+    if alg == MERKLE_ALG_LEGACY:
+        return compute_sha256_bytes(data=left + right)
     return compute_sha256_bytes(data=b"\x01" + left + right)
 
 
-def merkle_root_from_leaf_hashes(leaf_hashes: List[str]) -> str:
+def merkle_root_from_leaf_hashes(
+    leaf_hashes: List[str],
+    *,
+    alg: str = MERKLE_ALG_DEFAULT,
+) -> str:
+    _require_merkle_alg(alg)
     if not leaf_hashes:
         return compute_sha256(data=b"")
 
-    level = [_merkle_leaf(bytes.fromhex(leaf)) for leaf in leaf_hashes]
+    level = [_merkle_leaf(bytes.fromhex(leaf), alg) for leaf in leaf_hashes]
     while len(level) > 1:
         next_level = []
         for i in range(0, len(level), 2):
             left = level[i]
             right = level[i + 1] if i + 1 < len(level) else left
-            next_level.append(_merkle_parent(left, right))
+            next_level.append(_merkle_parent(left, right, alg))
         level = next_level
     return level[0].hex()
 
@@ -94,7 +130,9 @@ def build_merkle_manifest(
     file_path: Union[str, Path],
     *,
     chunk_size: int = MERKLE_CHUNK_SIZE_BYTES,
+    alg: str = MERKLE_ALG_DEFAULT,
 ) -> Dict[str, Any]:
+    _require_merkle_alg(alg)
     if chunk_size <= 0:
         raise ValueError("chunk_size must be a positive integer")
 
@@ -122,7 +160,8 @@ def build_merkle_manifest(
         "sha256": file_hash.hexdigest(),
         "chunk_size_bytes": chunk_size,
         "chunk_count": len(chunks),
-        "merkle_root": merkle_root_from_leaf_hashes(leaf_hashes),
+        "merkle_alg": alg,
+        "merkle_root": merkle_root_from_leaf_hashes(leaf_hashes, alg=alg),
         "chunks": chunks,
     }
 
@@ -146,14 +185,16 @@ def generate_merkle_proof(
     chunk_index: int,
     *,
     chunk_size: int = MERKLE_CHUNK_SIZE_BYTES,
+    alg: str = MERKLE_ALG_DEFAULT,
 ) -> List[Dict[str, Any]]:
-    manifest = build_merkle_manifest(file_path, chunk_size=chunk_size)
+    _require_merkle_alg(alg)
+    manifest = build_merkle_manifest(file_path, chunk_size=chunk_size, alg=alg)
     if manifest["chunk_count"] == 0:
         raise ValueError("Cannot generate a Merkle proof for an empty file")
     if chunk_index < 0 or chunk_index >= manifest["chunk_count"]:
         raise IndexError("chunk_index out of range")
 
-    level = [_merkle_leaf(bytes.fromhex(chunk["sha256"])) for chunk in manifest["chunks"]]
+    level = [_merkle_leaf(bytes.fromhex(chunk["sha256"]), alg) for chunk in manifest["chunks"]]
     proof = []
     index = chunk_index
     while len(level) > 1:
@@ -170,7 +211,7 @@ def generate_merkle_proof(
 
         next_level = []
         for i in range(0, len(level), 2):
-            next_level.append(_merkle_parent(level[i], level[i + 1]))
+            next_level.append(_merkle_parent(level[i], level[i + 1], alg))
         index //= 2
         level = next_level
     return proof
@@ -180,10 +221,13 @@ def verify_merkle_proof(
     chunk_bytes: bytes,
     proof: List[Dict[str, Any]],
     expected_root: str,
+    *,
+    alg: str = MERKLE_ALG_DEFAULT,
 ) -> bool:
     try:
+        _require_merkle_alg(alg)
         raw_hash = compute_sha256_bytes(data=chunk_bytes)
-        current = _merkle_leaf(raw_hash)
+        current = _merkle_leaf(raw_hash, alg)
         expected = bytes.fromhex(expected_root)
     except (TypeError, ValueError):
         return False
@@ -198,9 +242,9 @@ def verify_merkle_proof(
         if len(sibling) != hashlib.sha256().digest_size:
             return False
         if position == "left":
-            current = _merkle_parent(sibling, current)
+            current = _merkle_parent(sibling, current, alg)
         elif position == "right":
-            current = _merkle_parent(current, sibling)
+            current = _merkle_parent(current, sibling, alg)
         else:
             return False
 

--- a/src/publish.py
+++ b/src/publish.py
@@ -99,6 +99,7 @@ def prepare_publish_dir(
         "weights": dst.name,
         "sha256": merkle["sha256"],
         "merkle_root": merkle["merkle_root"],
+        "merkle_alg": merkle["merkle_alg"],
         "chunk_size_bytes": merkle["chunk_size_bytes"],
         "chunk_count": merkle["chunk_count"],
         "param_sha256": _tensor_hash(dst),

--- a/src/verifier.py
+++ b/src/verifier.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-from artifacts import build_merkle_manifest, compute_sha256, tensor_mapping_sha256
+from artifacts import (
+    MERKLE_ALG_LEGACY,
+    MERKLE_ALGS,
+    build_merkle_manifest,
+    compute_sha256,
+    tensor_mapping_sha256,
+)
 
 
 PASS = "PASS"
@@ -139,15 +145,40 @@ def check_artifact_hashes(model_dir: Path, manifest: Dict[str, Any]) -> List[Che
         )
     )
 
-    merkle = build_merkle_manifest(weights)
-    expected_root = (
-        manifest.get("merkle_root")
-        or manifest.get("weights_merkle_root")
-        or manifest.get("4_model_checkpoint_merkle_root")
-    )
-    results.append(
-        _check_equal("merkle_root", expected_root, merkle["merkle_root"], "1 MB chunk tree")
-    )
+    # A manifest with no merkle_alg predates the RFC 6962 hardening, so its root
+    # was built with the legacy construction. Recompute with the algorithm the
+    # manifest was actually written under -- otherwise an untampered artifact
+    # reports a root mismatch, which reads as tampering.
+    declared_alg = manifest.get("merkle_alg")
+    alg_known = declared_alg is None or declared_alg in MERKLE_ALGS
+    merkle_alg = declared_alg if declared_alg in MERKLE_ALGS else MERKLE_ALG_LEGACY
+
+    # chunk_count and sha256 are independent of the tree construction, so this
+    # is safe to build even when the declared algorithm is unrecognised.
+    merkle = build_merkle_manifest(weights, alg=merkle_alg)
+
+    if not alg_known:
+        results.append(
+            CheckResult(
+                "merkle_root",
+                FAIL,
+                f"manifest declares unknown merkle_alg {declared_alg!r}",
+                expected=f"one of {', '.join(MERKLE_ALGS)}",
+                actual=str(declared_alg),
+            )
+        )
+    else:
+        expected_root = (
+            manifest.get("merkle_root")
+            or manifest.get("weights_merkle_root")
+            or manifest.get("4_model_checkpoint_merkle_root")
+        )
+        detail = f"1 MB chunk tree ({merkle_alg})"
+        if declared_alg is None:
+            detail += " -- manifest predates merkle_alg; assumed legacy"
+        results.append(
+            _check_equal("merkle_root", expected_root, merkle["merkle_root"], detail)
+        )
 
     expected_chunks = (
         manifest.get("chunk_count")

--- a/tests/test_merkle_alg.py
+++ b/tests/test_merkle_alg.py
@@ -1,0 +1,230 @@
+"""Regression tests for the Merkle algorithm field and legacy compatibility.
+
+Commit 1ec4e5a hardened the Merkle tree with RFC 6962 domain separation but did
+not version the manifest format. Every manifest published before it recorded a
+root built with the old construction, so the new verifier recomputed a different
+root and reported PROVABLY UNTAMPERED artifacts as hash mismatches -- a false
+tampering alarm, the worst failure mode for a verification tool.
+
+These tests pin both halves of the fix: manifests are self-describing via
+``merkle_alg``, and a manifest without that field is still read as legacy.
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+try:
+    import torch
+    from safetensors.torch import save_file
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+from artifacts import (  # noqa: E402
+    MERKLE_ALG_LEGACY,
+    MERKLE_ALG_RFC6962,
+    build_merkle_manifest,
+    compute_sha256_bytes,
+    generate_merkle_proof,
+    merkle_root_from_leaf_hashes,
+    verify_merkle_proof,
+)
+
+
+class MerkleAlgTests(unittest.TestCase):
+    def _leaves(self, n):
+        return [compute_sha256_bytes(data=bytes([i])).hex() for i in range(n)]
+
+    def test_legacy_construction_is_bare_concatenation(self):
+        """The legacy root must stay reproducible or old manifests break again."""
+        leaves = self._leaves(2)
+        expected = compute_sha256_bytes(
+            data=bytes.fromhex(leaves[0]) + bytes.fromhex(leaves[1])
+        ).hex()
+        self.assertEqual(
+            merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_LEGACY), expected
+        )
+
+    def test_rfc6962_domain_separates_leaves_and_nodes(self):
+        leaves = self._leaves(2)
+        leaf_a = compute_sha256_bytes(data=b"\x00" + bytes.fromhex(leaves[0]))
+        leaf_b = compute_sha256_bytes(data=b"\x00" + bytes.fromhex(leaves[1]))
+        expected = compute_sha256_bytes(data=b"\x01" + leaf_a + leaf_b).hex()
+        self.assertEqual(
+            merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_RFC6962), expected
+        )
+
+    def test_algorithms_disagree(self):
+        leaves = self._leaves(4)
+        self.assertNotEqual(
+            merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_LEGACY),
+            merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_RFC6962),
+        )
+
+    def test_legacy_is_second_preimage_vulnerable_and_rfc6962_is_not(self):
+        """The security property that motivated the change.
+
+        Under the legacy tree an internal node can be replayed as a leaf: a
+        2-leaf tree and a 1-leaf tree whose leaf IS that internal node produce
+        the same root. Domain separation breaks the equivalence.
+        """
+        leaves = self._leaves(2)
+        legacy_root = merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_LEGACY)
+        forged = merkle_root_from_leaf_hashes([legacy_root], alg=MERKLE_ALG_LEGACY)
+        self.assertEqual(legacy_root, forged, "legacy tree should be forgeable")
+
+        hardened = merkle_root_from_leaf_hashes(leaves, alg=MERKLE_ALG_RFC6962)
+        forged_hardened = merkle_root_from_leaf_hashes(
+            [hardened], alg=MERKLE_ALG_RFC6962
+        )
+        self.assertNotEqual(
+            hardened, forged_hardened, "RFC 6962 tree must resist the replay"
+        )
+
+    def test_unknown_algorithm_is_rejected(self):
+        with self.assertRaises(ValueError):
+            merkle_root_from_leaf_hashes(self._leaves(2), alg="md5-vibes")
+
+    def test_manifest_records_its_algorithm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blob.bin"
+            path.write_bytes(b"abcdefgh")
+            manifest = build_merkle_manifest(path, chunk_size=4)
+            self.assertEqual(manifest["merkle_alg"], MERKLE_ALG_RFC6962)
+
+            legacy = build_merkle_manifest(path, chunk_size=4, alg=MERKLE_ALG_LEGACY)
+            self.assertEqual(legacy["merkle_alg"], MERKLE_ALG_LEGACY)
+            self.assertNotEqual(manifest["merkle_root"], legacy["merkle_root"])
+            # Byte-level facts must not depend on the tree construction.
+            self.assertEqual(manifest["sha256"], legacy["sha256"])
+            self.assertEqual(manifest["chunk_count"], legacy["chunk_count"])
+
+    def test_proofs_round_trip_under_both_algorithms(self):
+        for alg in (MERKLE_ALG_LEGACY, MERKLE_ALG_RFC6962):
+            with self.subTest(alg=alg):
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = Path(tmp) / "blob.bin"
+                    path.write_bytes(b"abcdefghijkl")
+                    manifest = build_merkle_manifest(path, chunk_size=4, alg=alg)
+                    proof = generate_merkle_proof(path, 1, chunk_size=4, alg=alg)
+                    self.assertTrue(
+                        verify_merkle_proof(
+                            b"efgh", proof, manifest["merkle_root"], alg=alg
+                        )
+                    )
+                    self.assertFalse(
+                        verify_merkle_proof(
+                            b"EFGH", proof, manifest["merkle_root"], alg=alg
+                        )
+                    )
+
+    def test_proof_does_not_verify_across_algorithms(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "blob.bin"
+            path.write_bytes(b"abcdefghijkl")
+            manifest = build_merkle_manifest(path, chunk_size=4, alg=MERKLE_ALG_RFC6962)
+            proof = generate_merkle_proof(path, 1, chunk_size=4, alg=MERKLE_ALG_RFC6962)
+            self.assertFalse(
+                verify_merkle_proof(
+                    b"efgh", proof, manifest["merkle_root"], alg=MERKLE_ALG_LEGACY
+                )
+            )
+
+
+@unittest.skipUnless(HAS_TORCH, "torch and safetensors required")
+class VerifierMerkleCompatTests(unittest.TestCase):
+    """The published-artifact regression, reproduced end to end."""
+
+    def _model_dir(self, tmp):
+        from publish import prepare_publish_dir
+
+        weights = Path(tmp) / "model.safetensors"
+        save_file(
+            {"layer.weight": torch.arange(8, dtype=torch.float32).reshape(2, 4)},
+            str(weights),
+        )
+        return prepare_publish_dir(weights=str(weights), output_dir=str(Path(tmp) / "pub"))
+
+    def _verify(self, model_dir):
+        from verifier import verify_model_reference
+
+        results = verify_model_reference(
+            str(model_dir), allow_unsigned=True, skip_replay=True
+        )
+        return {r.name: r for r in results}
+
+    def _rewrite_manifest(self, model_dir, mutate):
+        path = Path(model_dir) / "ovllm_manifest.json"
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        mutate(manifest)
+        path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        return manifest
+
+    def test_new_manifests_declare_the_algorithm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = self._model_dir(tmp)
+            manifest = json.loads(
+                (model_dir / "ovllm_manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["merkle_alg"], MERKLE_ALG_RFC6962)
+            self.assertEqual(self._verify(model_dir)["merkle_root"].status, "PASS")
+
+    def test_legacy_manifest_without_alg_field_still_verifies(self):
+        """A pre-hardening manifest must verify GREEN, not look tampered with."""
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = self._model_dir(tmp)
+            weights = model_dir / "model.safetensors"
+            legacy_root = build_merkle_manifest(weights, alg=MERKLE_ALG_LEGACY)[
+                "merkle_root"
+            ]
+
+            def to_legacy(manifest):
+                manifest.pop("merkle_alg", None)
+                manifest["merkle_root"] = legacy_root
+
+            self._rewrite_manifest(model_dir, to_legacy)
+
+            by_name = self._verify(model_dir)
+            self.assertEqual(by_name["merkle_root"].status, "PASS")
+            self.assertIn("assumed legacy", by_name["merkle_root"].detail)
+
+    def test_tampering_still_fails_under_legacy_manifest(self):
+        """Back-compat must not become a bypass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = self._model_dir(tmp)
+            weights = model_dir / "model.safetensors"
+            legacy_root = build_merkle_manifest(weights, alg=MERKLE_ALG_LEGACY)[
+                "merkle_root"
+            ]
+
+            def to_legacy(manifest):
+                manifest.pop("merkle_alg", None)
+                manifest["merkle_root"] = legacy_root
+
+            self._rewrite_manifest(model_dir, to_legacy)
+            weights.write_bytes(weights.read_bytes() + b"tamper")
+
+            by_name = self._verify(model_dir)
+            self.assertEqual(by_name["merkle_root"].status, "FAIL")
+            self.assertEqual(by_name["artifact_sha256"].status, "FAIL")
+
+    def test_unknown_algorithm_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = self._model_dir(tmp)
+            self._rewrite_manifest(
+                model_dir, lambda m: m.update({"merkle_alg": "md5-vibes"})
+            )
+            by_name = self._verify(model_dir)
+            self.assertEqual(by_name["merkle_root"].status, "FAIL")
+            self.assertIn("unknown merkle_alg", by_name["merkle_root"].detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Commit `1ec4e5a` hardened the Merkle tree with RFC 6962 domain separation (`0x00` leaf prefix, `0x01` internal prefix). That change is correct and worth keeping — it closes the second-preimage attack where an internal node can be replayed as a leaf. But it changed what `merkle_root` *means* without versioning the manifest, and it landed inside a commit whose message only describes moving artifacts into `runs/`.

Every manifest written before that commit records a root built with the old construction. The verifier recomputes with the new one, gets a different value, and reports a mismatch.

### The symptom

Our one published model verified **RED** against current `main` — while being provably untampered:

```
[PASS] artifact_sha256   172b9470…  ==  172b9470…
[FAIL] merkle_root       172b9470…  !=  83b9ae27…
[PASS] tensor_sha256     a4d9d36e…  ==  a4d9d36e…
VERDICT: RED
```

Raw bytes match. Tensor bytes match. The only thing that "failed" was our own recomputation. For a verification tool, a false tampering alarm on a clean artifact is the worst available failure mode — anyone running `ovllm verify` on that repo concludes we shipped a compromised model.

### The fix

Manifests are now self-describing. `build_merkle_manifest` stamps a `merkle_alg` field, and the tree functions (`merkle_root_from_leaf_hashes`, `generate_merkle_proof`, `verify_merkle_proof`) take the algorithm explicitly instead of hardcoding one construction.

A manifest with no `merkle_alg` is read as `sha256-concat` — which is what it was actually written with — and the verifier states the assumption in the check detail rather than making it silently:

```
[PASS] merkle_root - 1 MB chunk tree (sha256-concat) -- manifest predates merkle_alg; assumed legacy
```

New artifacts get `rfc6962-sha256`. `sha256` and `chunk_count` are computed independently of the tree, so they stay comparable across both.

### Back-compat is not a bypass

Explicitly tested:

- Tampering under a legacy manifest still fails **both** `merkle_root` and `artifact_sha256`
- An unrecognised `merkle_alg` fails loudly with `unknown merkle_alg`, rather than falling through to a confusing root mismatch
- A proof generated under one algorithm does not verify under the other

### Tests

`tests/test_merkle_alg.py`, 12 cases. Beyond the compat paths, it pins the security property that motivated the original change: the legacy tree is demonstrably forgeable (a 2-leaf tree and a 1-leaf tree containing its root produce the same root), and the RFC 6962 tree is not. Full suite: 54 passing.

### Verified against the live artifact

`ovllm verify Ryoari/openverifiable-smoke` now passes `merkle_root`. It still fails `sigstore_bundle` — that bundle was signed without `--identity`/`--identity-provider`, so the manifest lacks the fields the verifier needs. The publish workflow passes those flags, so a re-publish fixes it; that's a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RFC 6962 Merkle hashing as the default, with support for legacy SHA-256 compatibility.
  - Manifests now record the selected Merkle algorithm.
  - Proof generation and verification support algorithm selection and validation.

- **Bug Fixes**
  - Existing manifests without algorithm metadata continue to verify using legacy behavior.
  - Unknown algorithms are rejected clearly while preserving tamper detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->